### PR TITLE
Update MANIFEST.in to  resolve installation problem  via tar.gz

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include pgldapsync/config_default.ini
 include pgldapsync/config.ini.example
+include requirements.txt


### PR DESCRIPTION
After build python package by `python setup.py sdist bdist_wheel --universal`,   trying to install the package by` pip install pgldapsync-2.0.0.tar.gz` will raise exception 

```
 FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

add requiremnts.txt in the dist package solved the problem, verified.